### PR TITLE
fix multi footline spacing

### DIFF
--- a/theme/beamerinnerthemehbrs.sty
+++ b/theme/beamerinnerthemehbrs.sty
@@ -6,7 +6,5 @@
 \setbeamertemplate{itemize subsubitem}{\guillemotright}
 \setbeamertemplate{enumerate items}[default]
 
-\addtobeamertemplate{footnote}{}{\vspace{4ex}}
-
 \mode
 <all>

--- a/theme/beamerouterthemehbrs.sty
+++ b/theme/beamerouterthemehbrs.sty
@@ -115,6 +115,7 @@
 %% Footer
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 
+\patchcmd{\beamer@calculateheadfoot}{\advance\footheight by 4pt}{\advance\footheight by 5ex}{}{}
 \setbeamertemplate{navigation symbols}{}%remove navigation symbols
 
 \defbeamertemplate*{footline}{hbrs}{


### PR DESCRIPTION
# Description of Change

As discussed in #4, there is a apparent problem with the spacing in the case of multiple footlines. This is due to the `\vaspace{4ex}` that is added to the `\footline` command in the template.  
While it adds the requried spacing to avoid overlaying the actual footer created in the template, it adds the spacing to very footline and thereby produces an extremely large `vspace` between individual footlines, e.g. when using multiple `\footcite`s.

# Solution
As describe in the related issued, this behaviour can be fixed by removing the line in question and instead patching the command responsible for layouting the placement of the beamer frame and footerheight. This is what has been done in the pull request.  
